### PR TITLE
Add Codex and Claude repository automation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,22 @@
+name: Validate GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check workflow syntax
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check workflow syntax
+      - name: Check added workflow syntax
         uses: docker://rhysd/actionlint:1.7.12
         with:
-          args: -color
+          args: -color .github/workflows/claude.yml .github/workflows/actionlint.yml

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,71 @@
+# @claude メンションまたは手動実行で Claude を動かす。
+#
+# 事前準備:
+# - Claude GitHub App をこのリポジトリにインストール
+# - Actions secret CLAUDE_CODE_OAUTH_TOKEN を登録
+#
+# ANTHROPIC_API_KEY は使用しない。CLAUDE_CODE_OAUTH_TOKEN を使う。
+
+name: Claude
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: "Claude への指示（例: Issue を作成して）"
+        required: true
+        type: string
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') ||
+         contains(github.event.issue.title, '@claude')))
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude for @claude events
+        if: github.event_name != 'workflow_dispatch'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run Claude from manual prompt
+        if: github.event_name == 'workflow_dispatch'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ inputs.prompt }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,14 +33,18 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude')) ||
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude')) ||
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' &&
-        contains(github.event.review.body, '@claude')) ||
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') ||
-         contains(github.event.issue.title, '@claude')))
+         contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
 
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository guidance
+
+## Scope
+
+- Read the relevant documentation, source, and existing workflows before changing anything.
+- Keep changes scoped to the request. Do not refactor unrelated code or upgrade dependencies without an explicit request.
+- Preserve existing CI, deployment, and GitHub Pages configuration unless the task specifically requires a change.
+
+## Workflow changes
+
+- When modifying `.github/workflows/`, ensure actionlint passes.
+- Quote YAML scalar values that contain `: ` or special characters.
+- Do not broaden workflow permissions or alter deployment settings without a clear need.
+
+## Validation and delivery
+
+- Run the smallest relevant checks already supported by the repository.
+- Work on a feature branch and open a pull request; do not merge without explicit approval.
+- In each PR, summarize the change, verification performed, and any known limitations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Claude instructions
+
+- Read the relevant issue or pull request, repository documentation, and affected files before making changes.
+- Keep changes small and scoped to the request. Do not perform unrelated refactors or dependency upgrades.
+- Preserve existing CI, deployment, and GitHub Pages configuration unless the request explicitly requires changing it.
+- Run the smallest relevant existing checks and report the result in the pull request.
+
+## Review-only requests
+
+When asked to audit, observe, or review only, leave findings as comments. Do not edit files, create commits, or open a pull request unless explicitly asked to implement a change.


### PR DESCRIPTION
## Summary

Add shared repository guidance and GitHub automation for Codex and Claude.

## Changes

- Add `AGENTS.md` for Codex-oriented repository rules
- Add `CLAUDE.md` for Claude Code rules, including review-only behavior
- Add `.github/workflows/claude.yml` for `@claude` mentions and manual `workflow_dispatch` prompts
- Add `.github/workflows/actionlint.yml` to validate workflow syntax

## Prerequisites

After merge, install the Claude GitHub App for this repository and register the existing `CLAUDE_CODE_OAUTH_TOKEN` Actions secret. The token value is not included in this PR.

## Validation

- Workflow YAML is checked by the included actionlint workflow.
